### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "hapi-auth-bearer-token": "^4.0.0",
     "hapi-router": "^3.4.0",
     "jsonwebtoken": "^5.4.1",
-    "node-uuid": "^1.4.7",
     "nomajor-commit-analyzer": "^1.0.1",
-    "redis": "^2.4.2"
+    "redis": "^2.4.2",
+    "uuid": "^3.0.0"
   }
 }

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -1,6 +1,6 @@
 var Cache = require('../lib/cache')
 var JWT = require('jsonwebtoken')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 var crypto = require('crypto')
 
 // temp - load all users from a "database"

--- a/src/routes/logout.js
+++ b/src/routes/logout.js
@@ -1,6 +1,6 @@
 var Cache = require('../lib/cache')
 var JWT = require('jsonwebtoken')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 var crypto = require('crypto')
 var users = require('../users.json')
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.